### PR TITLE
Minor code tweaks

### DIFF
--- a/mydir.cabal
+++ b/mydir.cabal
@@ -25,7 +25,7 @@ executable mydir
      directory >= 1.3 && < 1.4,
      filepath >= 1.3 && < 1.5,
      process >= 1.1 && < 1.7,
-     unix >= 2.6 && < 2.8
+     unix >= 2.6 && < 2.9
 
   default-language: Haskell2010
 

--- a/src/MyDir.hs
+++ b/src/MyDir.hs
@@ -14,9 +14,10 @@ module Main where
 import qualified Control.Exception as C
 import qualified System.IO.Error as E
 
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromJust, fromMaybe, isJust)
 import qualified Data.List as L
 
+import Control.Arrow (second)
 import Control.Concurrent
 import Control.Monad
 
@@ -92,7 +93,7 @@ ls dname = C.try ls'
         ts <- mapM (getFileType . (dname </>)) fs
 
         let xs = filter (isJust . snd) $ zip fs ts
-            ys = map (\(a,Just b) -> (a,b)) xs
+            ys = map (second fromJust) xs
 
         return ys
 


### PR DESCRIPTION
Avoid an explicit incomplete pattern match failure with GHC 9.4 and update the OTS